### PR TITLE
Projektcontrolling

### DIFF
--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -101,7 +101,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
 [^9]: Beifuss A., Holzbaur U. (2020). *Projektmanagement für Studierende* (2. Auflage). Springer Gabler. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)
-[^11]: Steffens T. (2007). *Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung*. GRIN Verlag. https://www.grin.com/document/89579
+[^11]: Steffens T. (2007). *Projektcontrolling: Methoden der Planung, Kontrolle und Steuerung*. GRIN Verlag. https://www.grin.com/document/89579
 [^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan) (abgerufen am 14.12.2021)
 [^13]: [Meilensteintrendanalyse](https://de.wikipedia.org/wiki/Meilensteintrendanalyse) (abgerufen am 14.12.2021)
 [^14]: [Soll-Ist-Vergleich](https://www.kayenta.de/projektmanagement-glossar-lexikon/begriffserklaerung/soll-ist-vergleich.html) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -61,9 +61,9 @@ Den Mitarbeitern werden im Projektplan ihre Aufgaben sowie deren Bearbeitungszei
 
 ### Ampelmethode
 Durch die Visualisierung der Arbeitspaketestatus mit Ampelfarben, ist die Methode besonders intuitiv. Ein Nachteil der Methode ist der Auslegungsspielraum der Ampelfarben. Um diese Gefahr zu minimieren, ist es unabdingbar, die Farben klar zu definieren. Gemeinhin bedeuten die verschiedenen Ampelphasen:
-* <font color="green"> Grün: </font> Alles läuft nach Plan
-* Gelb: Es sind signifikante Planabweichungen zu befürchten
-* Rot:  Eine Zielerreichung scheint nicht mehr möglich[^3]
+* Grün: Alles läuft nach Plan.
+* Gelb: Es sind signifikante Planabweichungen zu befürchten.
+* Rot:  Eine Zielerreichung scheint nicht mehr möglich.[^3]
 
 ### Soll-Ist-Vergleich
 Hierbei handelt es sich um eine simple, sich selbsterklärende Methode. Es werden die ermittelten Ist-Werte mit den vom Kunden vorgegebenen Soll-Werten verglichen.

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -42,7 +42,7 @@ Die Kenngrößen des Dreiecks umfassen:
 *Überwachung der Kennzahlen des Projektdreiecks im Projektcontrolling-Kontext*[^10]
 
 ## Methoden
-Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im Projektcontrolling. Bei der Wahl der geeigneten Methode(n), sollten [Umfang](Projektumfang.md), Dauer und Komplexität des Projektes berücksichtigt werden.
+Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im Projektcontrolling. Bei der Wahl der geeigneten Methode(n), sollten Umfang, Dauer und Komplexität des Projektes berücksichtigt werden.
 
 Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**[^7]
 

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -19,8 +19,7 @@ Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach
 # Teilbereiche des Projektcontrollings 
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
-**Projektkalkulation:**
-
+* **Projektkalkulation:**
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
 **Projektleistung:**

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -22,13 +22,11 @@ Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkul
 * **Projektkalkulation:**
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
-**Projektleistung:**
+* **Projektleistung:**
+            Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
 
-Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
-
-**Projektkontrolle:**
-
-Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten.[^6] 
+* **Projektkontrolle:**
+            Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten.[^6] 
 
 # Kennzahlen und Methoden
 ## Kennzahlen

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -61,9 +61,9 @@ Den Mitarbeitern werden im Projektplan ihre Aufgaben sowie deren Bearbeitungszei
 
 ### Ampelmethode
 Durch die Visualisierung der Arbeitspaketestatus mit Ampelfarben, ist die Methode besonders intuitiv. Ein Nachteil der Methode ist der Auslegungsspielraum der Ampelfarben. Um diese Gefahr zu minimieren, ist es unabdingbar, die Farben klar zu definieren. Gemeinhin bedeuten die verschiedenen Ampelphasen:
-* Grün: Alles läuft nach Plan.
-* Gelb: Es sind signifikante Planabweichungen zu befürchten.
-* Rot:  Eine Zielerreichung scheint nicht mehr möglich.[^3]
+* Grün:   Alles läuft nach Plan.
+* Gelb:   Es sind signifikante Planabweichungen zu befürchten.
+* Rot:    Eine Zielerreichung scheint nicht mehr möglich.[^3]
 
 ### Soll-Ist-Vergleich
 Hierbei handelt es sich um eine simple, sich selbsterklärende Methode. Es werden die ermittelten Ist-Werte mit den vom Kunden vorgegebenen Soll-Werten verglichen.

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -88,7 +88,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
   * [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/)
   * [Kurs Projekt- und Zeitmanagement: Projektcontrolling](https://www.youtube.com/watch?v=2OTCNh0TzLw)
 * Deep Dive: 
-  * https://www.youtube.com/watch?v=la1PUSoGBxk
+  * [Controlling in Projekten – auf was Sie bei Einzel- und Multiprojekten dringend achten sollten](https://www.youtube.com/watch?v=la1PUSoGBxk)
   * Zirkler B., Nobach K., Hofmann J., Behrens S. (2019) Das Projektcontrolling. In: Projektcontrolling. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-23714-1_3
 
 # Quellen

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -44,7 +44,7 @@ Die Kenngrößen des Dreiecks umfassen:
 ## Methoden
 Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im Projektcontrolling. Bei der Wahl der geeigneten Methode(n), sollten [Umfang](Projektumfang.md), Dauer und Komplexität des Projektes berücksichtigt werden.
 
-Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**
+Grundsätzlich gilt hier die Devise: ***Je einfacher und durschaubarer die Methode, desto besser.***
 
 ### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
 Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt. Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.[^13]

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -93,7 +93,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 # Quellen
 
-[^3]: [Teilbereiche des Projektcontrolling](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) 
+[^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) 
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
 [^5]: https://doi.org/10.1007/978-3-658-28032-1
 [^6]: https://refa.de/service/refa-lexikon/projektcontrolling

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -96,7 +96,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) 
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
 [^5]: https://doi.org/10.1007/978-3-658-28032-1
-[^6]: https://refa.de/service/refa-lexikon/projektcontrolling
+[^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling)
 [^7]: Bär C., Fiege J., Weiß M. (2017) Projektcontrolling. In: Anwendungsbezogenes Projektmanagement. Xpert.press. Springer Vieweg, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-52974-4_8
 [^8]: https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings
 [^9]: Beifuss A., Holzbaur U. (2020) Projektcontrolling. In: Projektmanagement für Studierende. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -104,4 +104,4 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^11]: Steffens T. (2007) Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
 [^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan)
 [^13]: [Meilensteintrendanalyse](https://de.wikipedia.org/wiki/Meilensteintrendanalyse)
-[^14]: [Soll-Ist-Vergleich](https://www.kayenta.de/projektmanagement-glossar-lexikon/begriffserklaerung/soll-ist-vergleich.html)
+[^14]: [Soll-Ist-Vergleich](https://www.kayenta.de/projektmanagement-glossar-lexikon/begriffserklaerung/soll-ist-vergleich.html) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -85,7 +85,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 # Weiterführende Literatur
 
 * Basics
-  * https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/
+  * [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/)
   * https://www.youtube.com/watch?v=2OTCNh0TzLw
 * Deep Dive: 
   * https://www.youtube.com/watch?v=la1PUSoGBxk

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -19,7 +19,7 @@ Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach
 # Teilbereiche des Projektcontrollings 
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
-* **Projektkalkulation:**
+* **Projektkalkulation:**  
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
 * **Projektleistung:**

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -44,7 +44,7 @@ Die Kenngrößen des Dreiecks umfassen:
 ## Methoden
 Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im Projektcontrolling. Bei der Wahl der geeigneten Methode(n), sollten [Umfang](Projektumfang.md), Dauer und Komplexität des Projektes berücksichtigt werden.
 
-Grundsätzlich gilt hier die Devise: ***Je einfacher und durschaubarer die Methode, desto besser.***[^7]
+Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**[^7]
 
 ### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
 Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt. Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.[^13]

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -46,7 +46,7 @@ Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im 
 
 Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**
 
-### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
+#### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
 Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt. Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.[^13]
 
 ### Earned Value Analyse

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -93,7 +93,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 # Quellen
 
-[^3]: https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/ 
+[^3]: [Projektcontrolling](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) 
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
 [^5]: https://doi.org/10.1007/978-3-658-28032-1
 [^6]: https://refa.de/service/refa-lexikon/projektcontrolling

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -99,7 +99,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
 [^7]: Bär C., Fiege J., Weiß M. (2017).*Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*.Springer Vieweg.https://doi.org/10.1007/978-3-662-52974-4_8.
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
-[^9]: Beifuss A., Holzbaur U. (2020). *Projektcontrolling. In: Projektmanagement für Studierende*. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
+[^9]: Beifuss A., Holzbaur U. (2020). *Projektcontrolling. In: Projektmanagement für Studierende*. Springer Gabler. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)
 [^11]: Steffens T. (2007). Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
 [^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -102,6 +102,6 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^9]: Beifuss A., Holzbaur U. (2020) Projektcontrolling. In: Projektmanagement für Studierende. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html)
 [^11]: Steffens T. (2007) Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
-[^12]: https://www.projektmagazin.de/glossarterm/projektplan
+[^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan)
 [^13]: [Meilensteintrendanalyse](https://de.wikipedia.org/wiki/Meilensteintrendanalyse)
 [^14]: [Soll-Ist-Vergleich](https://www.kayenta.de/projektmanagement-glossar-lexikon/begriffserklaerung/soll-ist-vergleich.html)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -7,7 +7,7 @@ anrechnung: k
 
 Das Projektcontrolling ist ein Bestandteil des [Projektmanagements](Projektmanagement.md).[^6] Es handelt sich dabei um einen [Steuerungs](Projektsteuerung.md)- und Koordinationsprozess[^4], der durch die [DIN 69901-5](https://de.wikipedia.org/wiki/DIN_69901) als "Sicherung des Erreichens der Projektziele durch: Soll-Ist-Vergleich, Feststellung der Abweichungen, Bewerten der Konsequenzen und Vorschlagen von Korrekturmaßnahmen, Mitwirkung bei der Maßnahmenplanung und Kontrolle der Durchführung" [^5]
 definiert wird.
-# 1 Controlling Regelkreis
+# Controlling Regelkreis
 Häufig wird (Projekt-)Controlling fälschlicherweise mit Kontrolle gleichgesetzt, es umfasst allerdings weitaus mehr. Die verschiedenen Schritte des Controlling-Prozesses sind in der folgenden Abbildung als projektspezifischer „Controlling Regelkreis“ illustriert.
 
 ![Controlling Regelkreis](Projektcontrolling/ControllingRegelkreis.jpg)
@@ -16,20 +16,20 @@ Häufig wird (Projekt-)Controlling fälschlicherweise mit Kontrolle gleichgesetz
 
 Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach dem [Projektumfang](Projektumfang.md) richten sollte. Dabei kann sowohl das gesamte [Projekt](Projekt.md), als auch nur einzelne [Phasen](Projektphasen_klassisch.md) betrachtet werden.[^3]
 
-# 2 Teilbereiche des Projektcontrollings[^6] 
+# Teilbereiche des Projektcontrollings[^6] 
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
-## 2.1 Projektkalkulation
+## Projektkalkulation
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
-## 2.2 Projektleistung
+## Projektleistung
 Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
 
-## 2.3 Projektkontrolle
+## Projektkontrolle
 Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten. 
 
-# 3 Kennzahlen und Methoden
-## 3.1 Kennzahlen
+# Kennzahlen und Methoden
+## Kennzahlen
 Die elementare Basisgröße des Projektcontrollings ist der Projekterfolg.[^11] Dieser ist [messbar](Erfolgsmessung.md) anhand der drei Kenngrößen des [Projektdreiecks](Magisches_Dreieck.md), welche im Laufe des Projekts geplant und anschließend überwacht werden müssen.[^9]
 Die Kenngrößen des Dreiecks umfassen:
 
@@ -41,31 +41,31 @@ Die Kenngrößen des Dreiecks umfassen:
 
 *Überwachung der Kennzahlen des Projektdreiecks im Projektcontrolling-Kontext*[^10]
 
-## 3.2 Methoden
+## Methoden
 Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im Projektcontrolling. Bei der Wahl der geeigneten Methode(n), sollten [Umfang](Projektumfang.md), Dauer und Komplexität des Projektes berücksichtigt werden.
 
 Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**
 
-### 3.2.1 [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
+### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
 Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt.[^13] Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.
 
-### 3.2.2 Earned Value Analyse
+### Earned Value Analyse
 Eine weitere Methode ist die Earned Value Analyse, mit der man den Fertigstellungsgrad des Projekts bzw. einzelner Phasen ermitteln kann. Sie dient dem Projekt als Kontrollinstrument des Fortschritts. Diese Methode ist ebenfalls unter den Namen Leistungswertanalyse, Fertigstellungswertmethode oder Arbeitswertanalyse bekannt.[^7]
 
-### 3.2.3 Projektplan
+### Projektplan
 Den Mitarbeitern werden im Projektplan ihre Aufgaben sowie deren Bearbeitungszeiträume zugeteilt. Der Projektmanager hat somit stets den Überblick über die [Aufgabenteilung](Aufgabenteilung.md) und Termintreue der jeweiligen Projektabschnitte.[^8] Der Umfang des Projektplans richtet sich nach der Größe und Komplexität des Projekts. Folgende Pläne sollten aber in jedem Fall enthalten sein:
 * [Projektstrukturplan](Projektstrukturplan.md)
 * Ablaufplan (als Tabelle, [Netzplan](Netzplantechnik.md) oder [Gantt-Diagramm](Gantt_Diagramme.md))
 * [Kostenplan](Kostenplanung.md)
 * [Ressourcenplan](Ressourcenplanung.md)[^12]
 
-### 3.2.4 Ampelmethode
+### Ampelmethode
 Durch die Visualisierung der Arbeitspaketestatus mit Ampelfarben, ist die Methode besonders intuitiv. Ein Nachteil der Methode ist der Auslegungsspielraum der Ampelfarben. Um diese Gefahr zu minimieren, ist es unabdingbar, die Farben klar zu definieren. Gemeinhin bedeuten die verschiedenen Ampelphasen:
 * <font color="green"> Grün: </font> Alles läuft nach Plan
 * Gelb: Es sind signifikante Planabweichungen zu befürchten
 * Rot:  Eine Zielerreichung scheint nicht mehr möglich[^3]
 
-### 3.2.5 Soll-Ist-Vergleich
+### Soll-Ist-Vergleich
 Hierbei handelt es sich um eine simple, sich selbsterklärende Methode. Es werden die ermittelten Ist-Werte mit den vom Kunden vorgegebenen Soll-Werten verglichen.
 Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. sein. Aus dem Vergleich ergibt sich ein Gesamtunterschied zwischen den geplanten und tatsächlichen Werten. Sind die Ist-Werte besser als die Soll-Werte, fällt der Soll-Ist-Vergleich positiv, andernfalls negativ aus.[^14]
 

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -47,7 +47,7 @@ Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im 
 Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**[^7]
 
 ### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
-Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt. Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.[^13]
+Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt. Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle Meilenstein-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.[^13]
 
 ### Earned Value Analyse
 Eine weitere Methode ist die Earned Value Analyse, mit der man den Fertigstellungsgrad des Projekts bzw. einzelner Phasen ermitteln kann. Sie dient dem Projekt als Kontrollinstrument des Fortschritts. Diese Methode ist ebenfalls unter den Namen Leistungswertanalyse, Fertigstellungswertmethode oder Arbeitswertanalyse bekannt.[^7]

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -85,6 +85,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften u.v.m
 * [Ressourcenplan](Ressourcenplanung.md)
 * [Projektplanung](Projektplanung.md)
 * [Projekt](Projekt.md)
+* [Das magische Dreieck im Projektmanagement](Magisches_Dreieck.md)
 # Weiterführende Literatur
 
 * Basics

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -101,7 +101,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
 [^9]: Beifuss A., Holzbaur U. (2020). *Projektcontrolling. In: Projektmanagement für Studierende*. Springer Gabler. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)
-[^11]: Steffens T. (2007). Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
+[^11]: Steffens T. (2007). *Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung*. GRIN Verlag. https://www.grin.com/document/89579
 [^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan) (abgerufen am 14.12.2021)
 [^13]: [Meilensteintrendanalyse](https://de.wikipedia.org/wiki/Meilensteintrendanalyse) (abgerufen am 14.12.2021)
 [^14]: [Soll-Ist-Vergleich](https://www.kayenta.de/projektmanagement-glossar-lexikon/begriffserklaerung/soll-ist-vergleich.html) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -86,7 +86,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 * Basics
   * [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/)
-  * https://www.youtube.com/watch?v=2OTCNh0TzLw
+  * [Kurs Projekt- und Zeitmanagement: Projektcontrolling](https://www.youtube.com/watch?v=2OTCNh0TzLw)
 * Deep Dive: 
   * https://www.youtube.com/watch?v=la1PUSoGBxk
   * Zirkler B., Nobach K., Hofmann J., Behrens S. (2019) Das Projektcontrolling. In: Projektcontrolling. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-23714-1_3

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -23,10 +23,12 @@ Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkul
 
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
-## Projektleistung
+* **Projektleistung:**
+
 Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
 
-## Projektkontrolle
+* **Projektkontrolle:**
+
 Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten.[^6] 
 
 # Kennzahlen und Methoden

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -22,11 +22,11 @@ Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkul
 * **Projektkalkulation:**  
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
-* **Projektleistung:**
-            Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
+* **Projektleistung:**  
+Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
 
-* **Projektkontrolle:**
-            Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten.[^6] 
+* **Projektkontrolle:**  
+Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten.[^6] 
 
 # Kennzahlen und Methoden
 ## Kennzahlen

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -19,7 +19,7 @@ Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach
 # Teilbereiche des Projektcontrollings 
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
-## Projektkalkulation
+* **Projektkalkulation**
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
 ## Projektleistung

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -95,13 +95,13 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 [^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) (abgerufen am 14.12.2021)
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
-[^5]: Fiedler R. (2020) *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle* https://doi.org/10.1007/978-3-658-28032-1
+[^5]: Fiedler R. (2020). *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle* https://doi.org/10.1007/978-3-658-28032-1
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
 [^7]: Bär C., Fiege J., Weiß M. (2017) *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Xpert.press. Springer Vieweg, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-52974-4_8
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
-[^9]: Beifuss A., Holzbaur U. (2020) *Projektcontrolling. In: Projektmanagement für Studierende*. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
+[^9]: Beifuss A., Holzbaur U. (2020). *Projektcontrolling. In: Projektmanagement für Studierende*. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)
-[^11]: Steffens T. (2007) Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
+[^11]: Steffens T. (2007). Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
 [^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan) (abgerufen am 14.12.2021)
 [^13]: [Meilensteintrendanalyse](https://de.wikipedia.org/wiki/Meilensteintrendanalyse) (abgerufen am 14.12.2021)
 [^14]: [Soll-Ist-Vergleich](https://www.kayenta.de/projektmanagement-glossar-lexikon/begriffserklaerung/soll-ist-vergleich.html) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -95,7 +95,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 [^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) (abgerufen am 14.12.2021)
 [^4]: Zirkler B., Nobach K., Hofmann J., Behrens S. (2019). *Projektcontrolling: Leitfaden für die betriebliche Praxis*. Springer Gabler. https://doi.org/10.1007/978-3-658-23714-1
-[^5]: Fiedler R. (2020). *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle*. Springer Vieweg. https://doi.org/10.1007/978-3-658-28032-1.
+[^5]: Fiedler R. (2020). *Controlling von Projekten: Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle*. Springer Vieweg. https://doi.org/10.1007/978-3-658-28032-1.
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
 [^7]: Bär C., Fiege J., Weiß M. (2017). *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Springer Vieweg. https://doi.org/10.1007/978-3-662-52974-4_8.
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -49,7 +49,7 @@ Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Method
 #### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
 Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt. Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.[^13]
 
-### Earned Value Analyse
+#### Earned Value Analyse
 Eine weitere Methode ist die Earned Value Analyse, mit der man den Fertigstellungsgrad des Projekts bzw. einzelner Phasen ermitteln kann. Sie dient dem Projekt als Kontrollinstrument des Fortschritts. Diese Methode ist ebenfalls unter den Namen Leistungswertanalyse, Fertigstellungswertmethode oder Arbeitswertanalyse bekannt.[^7]
 
 ### Projektplan

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -83,7 +83,8 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften u.v.m
 * [Projektphasen](Projektphasen_klassisch.md)
 * [Kostenplan](Kostenplanung.md)
 * [Ressourcenplan](Ressourcenplanung.md)
-
+* [Projektplanung](Projektplanung.md)
+* [Projekt](Projekt.md)
 # Weiterführende Literatur
 
 * Basics

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -98,9 +98,9 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^5]: https://doi.org/10.1007/978-3-658-28032-1
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling)
 [^7]: Bär C., Fiege J., Weiß M. (2017) Projektcontrolling. In: Anwendungsbezogenes Projektmanagement. Xpert.press. Springer Vieweg, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-52974-4_8
-[^8]: https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings
+[^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings)
 [^9]: Beifuss A., Holzbaur U. (2020) Projektcontrolling. In: Projektmanagement für Studierende. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
-[^10]: https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html
+[^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html)
 [^11]: Steffens T. (2007) Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
 [^12]: https://www.projektmagazin.de/glossarterm/projektplan
 [^13]: https://de.wikipedia.org/wiki/Meilensteintrendanalyse

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -89,7 +89,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
   * [Kurs Projekt- und Zeitmanagement: Projektcontrolling](https://www.youtube.com/watch?v=2OTCNh0TzLw)
 * Deep Dive: 
   * [Controlling in Projekten – auf was Sie bei Einzel- und Multiprojekten dringend achten sollten](https://www.youtube.com/watch?v=la1PUSoGBxk)
-  * Zirkler B., Nobach K., Hofmann J., Behrens S. (2019) Das Projektcontrolling. In: Projektcontrolling. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-23714-1_3
+  * Zirkler B., Nobach K., Hofmann J., Behrens S. (2019) *Projektcontrolling: Leitfaden für die betriebliche Praxis*. Springer Gabler. https://doi.org/10.1007/978-3-658-23714-1_3
 
 # Quellen
 

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -93,7 +93,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 # Quellen
 
-[^3]: [Projektcontrolling](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) 
+[^3]: [Teilbereiche des Projektcontrolling](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) 
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
 [^5]: https://doi.org/10.1007/978-3-658-28032-1
 [^6]: https://refa.de/service/refa-lexikon/projektcontrolling

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -44,7 +44,7 @@ Die Kenngrößen des Dreiecks umfassen:
 ## Methoden
 Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im Projektcontrolling. Bei der Wahl der geeigneten Methode(n), sollten [Umfang](Projektumfang.md), Dauer und Komplexität des Projektes berücksichtigt werden.
 
-Grundsätzlich gilt hier die Devise: ***Je einfacher und durschaubarer die Methode, desto besser.***
+Grundsätzlich gilt hier die Devise: ***Je einfacher und durschaubarer die Methode, desto besser.***[^7]
 
 ### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
 Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt. Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.[^13]

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -99,7 +99,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
 [^7]: Bär C., Fiege J., Weiß M. (2017). *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Springer Vieweg. https://doi.org/10.1007/978-3-662-52974-4_8.
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
-[^9]: Beifuss A., Holzbaur U. (2020). *Projektcontrolling. In: Projektmanagement für Studierende*. Springer Gabler. https://doi.org/10.1007/978-3-658-32664-7_4
+[^9]: Beifuss A., Holzbaur U. (2020). *Projektmanagement für Studierende* (2. Auflage). Springer Gabler. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)
 [^11]: Steffens T. (2007). *Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung*. GRIN Verlag. https://www.grin.com/document/89579
 [^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -53,7 +53,7 @@ Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode
 Eine weitere Methode ist die Earned Value Analyse, mit der man den Fertigstellungsgrad des Projekts bzw. einzelner Phasen ermitteln kann. Sie dient dem Projekt als Kontrollinstrument des Fortschritts. Diese Methode ist ebenfalls unter den Namen Leistungswertanalyse, Fertigstellungswertmethode oder Arbeitswertanalyse bekannt.[^7]
 
 ### Projektplan
-Den Mitarbeitern werden im Projektplan ihre Aufgaben sowie deren Bearbeitungszeiträume zugeteilt. Der Projektmanager hat somit stets den Überblick über die [Aufgabenteilung](Aufgabenteilung.md) und Termintreue der jeweiligen Projektabschnitte.[^8] Der Umfang des Projektplans richtet sich nach der Größe und Komplexität des Projekts. Folgende Pläne sollten aber in jedem Fall enthalten sein:
+Im Projektplan werden den Mitarbeitern ihre Aufgaben sowie deren Bearbeitungszeiträume zugeteilt. Der Projektmanager hat somit stets den Überblick über die [Aufgabenteilung](Aufgabenteilung.md) und Termintreue der jeweiligen Projektabschnitte.[^8] Der Umfang des Projektplans richtet sich nach der Größe und Komplexität des Projekts. Folgende Pläne sollten aber in jedem Fall enthalten sein:
 * [Projektstrukturplan](Projektstrukturplan.md),
 * Ablaufplan (als Tabelle, [Netzplan](Netzplantechnik.md) oder [Gantt-Diagramm](Gantt_Diagramme.md)),
 * [Kostenplan](Kostenplanung.md),

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -20,7 +20,7 @@ Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
 * **Projektkalkulation:**  
-In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
+In der Vorbereitungs- und Planungsphase werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
 * **Projektleistung:**  
 Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -81,6 +81,8 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 * [Netzplan](Netzplantechnik.md)
 * [Gantt-Diagramm](Gantt_Diagramme.md)
 * [Projektphasen](Projektphasen_klassisch.md)
+* [Kostenplan](Kostenplanung.md)
+* [Ressourcenplan](Ressourcenplanung.md)
 
 # Weiterführende Literatur
 

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -94,7 +94,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 # Quellen
 
 [^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) (abgerufen am 14.12.2021)
-[^4]: Zirkler B., Nobach K., Hofmann J., Behrens S. (2020). *Projektcontrolling: Leitfaden für die betriebliche Praxis*. Springer Gabler. https://doi.org/10.1007/978-3-658-23714-1
+[^4]: Zirkler B., Nobach K., Hofmann J., Behrens S. (2019). *Projektcontrolling: Leitfaden für die betriebliche Praxis*. Springer Gabler. https://doi.org/10.1007/978-3-658-23714-1
 [^5]: Fiedler R. (2020). *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle*. Springer Vieweg. https://doi.org/10.1007/978-3-658-28032-1.
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
 [^7]: Bär C., Fiege J., Weiß M. (2017). *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Springer Vieweg. https://doi.org/10.1007/978-3-662-52974-4_8.

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -103,5 +103,5 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html)
 [^11]: Steffens T. (2007) Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
 [^12]: https://www.projektmagazin.de/glossarterm/projektplan
-[^13]: https://de.wikipedia.org/wiki/Meilensteintrendanalyse
-[^14]:https://www.kayenta.de/projektmanagement-glossar-lexikon/begriffserklaerung/soll-ist-vergleich.html
+[^13]: [Meilensteintrendanalyse](https://de.wikipedia.org/wiki/Meilensteintrendanalyse)
+[^14]: [Soll-Ist-Vergleich](https://www.kayenta.de/projektmanagement-glossar-lexikon/begriffserklaerung/soll-ist-vergleich.html)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -7,7 +7,7 @@ anrechnung: k
 
 Das Projektcontrolling ist ein Bestandteil des [Projektmanagements](Projektmanagement.md).[^6] Es handelt sich dabei um einen [Steuerungs](Projektsteuerung.md)- und Koordinationsprozess[^4], der durch die [DIN 69901-5](https://de.wikipedia.org/wiki/DIN_69901) als "Sicherung des Erreichens der Projektziele durch: Soll-Ist-Vergleich, Feststellung der Abweichungen, Bewerten der Konsequenzen und Vorschlagen von Korrekturmaßnahmen, Mitwirkung bei der Maßnahmenplanung und Kontrolle der Durchführung" [^5]
 definiert wird.
-# Controlling Regelkreis
+# 1 Controlling Regelkreis
 Häufig wird (Projekt-)Controlling fälschlicherweise mit Kontrolle gleichgesetzt, es umfasst allerdings weitaus mehr. Die verschiedenen Schritte des Controlling-Prozesses sind in der folgenden Abbildung als projektspezifischer „Controlling Regelkreis“ illustriert.
 
 ![Controlling Regelkreis](Projektcontrolling/ControllingRegelkreis.jpg)
@@ -16,20 +16,20 @@ Häufig wird (Projekt-)Controlling fälschlicherweise mit Kontrolle gleichgesetz
 
 Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach dem [Projektumfang](Projektumfang.md) richten sollte. Dabei kann sowohl das gesamte [Projekt](Projekt.md), als auch nur einzelne [Phasen](Projektphasen_klassisch.md) betrachtet werden.[^3]
 
-# Teilbereiche des Projektcontrollings[^6] 
+# 2 Teilbereiche des Projektcontrollings[^6] 
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
-## Projektkalkulation
+## 2.1 Projektkalkulation
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
-## Projektleistung
+## 2.2 Projektleistung
 Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
 
-## Projektkontrolle
+## 2.3 Projektkontrolle
 Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten. 
 
-# Kennzahlen und Methoden
-## Kennzahlen
+# 3 Kennzahlen und Methoden
+## 3.1 Kennzahlen
 Die elementare Basisgröße des Projektcontrollings ist der Projekterfolg.[^11] Dieser ist [messbar](Erfolgsmessung.md) anhand der drei Kenngrößen des [Projektdreiecks](Magisches_Dreieck.md), welche im Laufe des Projekts geplant und anschließend überwacht werden müssen.[^9]
 Die Kenngrößen des Dreiecks umfassen:
 
@@ -41,31 +41,31 @@ Die Kenngrößen des Dreiecks umfassen:
 
 *Überwachung der Kennzahlen des Projektdreiecks im Projektcontrolling-Kontext*[^10]
 
-## Methoden
+## 3.2 Methoden
 Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im Projektcontrolling. Bei der Wahl der geeigneten Methode(n), sollten [Umfang](Projektumfang.md), Dauer und Komplexität des Projektes berücksichtigt werden.
 
 Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**
 
-### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
+### 3.2.1 [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
 Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt.[^13] Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.
 
-### Earned Value Analyse
+### 3.2.2 Earned Value Analyse
 Eine weitere Methode ist die Earned Value Analyse, mit der man den Fertigstellungsgrad des Projekts bzw. einzelner Phasen ermitteln kann. Sie dient dem Projekt als Kontrollinstrument des Fortschritts. Diese Methode ist ebenfalls unter den Namen Leistungswertanalyse, Fertigstellungswertmethode oder Arbeitswertanalyse bekannt.[^7]
 
-### Projektplan
+### 3.2.3 Projektplan
 Den Mitarbeitern werden im Projektplan ihre Aufgaben sowie deren Bearbeitungszeiträume zugeteilt. Der Projektmanager hat somit stets den Überblick über die [Aufgabenteilung](Aufgabenteilung.md) und Termintreue der jeweiligen Projektabschnitte.[^8] Der Umfang des Projektplans richtet sich nach der Größe und Komplexität des Projekts. Folgende Pläne sollten aber in jedem Fall enthalten sein:
 * [Projektstrukturplan](Projektstrukturplan.md)
 * Ablaufplan (als Tabelle, [Netzplan](Netzplantechnik.md) oder [Gantt-Diagramm](Gantt_Diagramme.md))
 * [Kostenplan](Kostenplanung.md)
 * [Ressourcenplan](Ressourcenplanung.md)[^12]
 
-### Ampelmethode
+### 3.2.4 Ampelmethode
 Durch die Visualisierung der Arbeitspaketestatus mit Ampelfarben, ist die Methode besonders intuitiv. Ein Nachteil der Methode ist der Auslegungsspielraum der Ampelfarben. Um diese Gefahr zu minimieren, ist es unabdingbar, die Farben klar zu definieren. Gemeinhin bedeuten die verschiedenen Ampelphasen:
 * <font color="green"> Grün: </font> Alles läuft nach Plan
 * Gelb: Es sind signifikante Planabweichungen zu befürchten
 * Rot:  Eine Zielerreichung scheint nicht mehr möglich[^3]
 
-### Soll-Ist-Vergleich
+### 3.2.5 Soll-Ist-Vergleich
 Hierbei handelt es sich um eine simple, sich selbsterklärende Methode. Es werden die ermittelten Ist-Werte mit den vom Kunden vorgegebenen Soll-Werten verglichen.
 Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. sein. Aus dem Vergleich ergibt sich ein Gesamtunterschied zwischen den geplanten und tatsächlichen Werten. Sind die Ist-Werte besser als die Soll-Werte, fällt der Soll-Ist-Vergleich positiv, andernfalls negativ aus.[^14]
 

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -30,12 +30,12 @@ Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus]
 
 # Kennzahlen und Methoden
 ## Kennzahlen
-Die elementare Basisgröße des Projektcontrollings ist der Projekterfolg.[^11] Dieser ist [messbar](Erfolgsmessung.md) anhand der drei Kenngrößen des [Projektdreiecks](Magisches_Dreieck.md), welche im Laufe des Projekts geplant und anschließend überwacht werden müssen.[^9]
+Die elementare Basisgröße des Projektcontrollings ist der Projekterfolg.[^11] Dieser ist [messbar](Erfolgsmessung.md) anhand der drei Kenngrößen des [Projektdreiecks](Magisches_Dreieck.md), welche im Laufe des Projekts geplant und anschließend überwacht werden müssen.
 Die Kenngrößen des Dreiecks umfassen:
 
-* Termine
-* Qualität
-* Kosten
+* Termine,
+* Qualität,
+* Kosten.[^9]
 
 ![Projekt Controlling](Projektcontrolling/projectcontrolling.jpg)
 
@@ -54,9 +54,9 @@ Eine weitere Methode ist die Earned Value Analyse, mit der man den Fertigstellun
 
 ### Projektplan
 Den Mitarbeitern werden im Projektplan ihre Aufgaben sowie deren Bearbeitungszeiträume zugeteilt. Der Projektmanager hat somit stets den Überblick über die [Aufgabenteilung](Aufgabenteilung.md) und Termintreue der jeweiligen Projektabschnitte.[^8] Der Umfang des Projektplans richtet sich nach der Größe und Komplexität des Projekts. Folgende Pläne sollten aber in jedem Fall enthalten sein:
-* [Projektstrukturplan](Projektstrukturplan.md)
-* Ablaufplan (als Tabelle, [Netzplan](Netzplantechnik.md) oder [Gantt-Diagramm](Gantt_Diagramme.md))
-* [Kostenplan](Kostenplanung.md)
+* [Projektstrukturplan](Projektstrukturplan.md),
+* Ablaufplan (als Tabelle, [Netzplan](Netzplantechnik.md) oder [Gantt-Diagramm](Gantt_Diagramme.md)),
+* [Kostenplan](Kostenplanung.md),
 * [Ressourcenplan](Ressourcenplanung.md).[^12]
 
 ### Ampelmethode

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -95,7 +95,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 [^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) 
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
-[^5]: https://doi.org/10.1007/978-3-658-28032-1
+[^5]: Fiedler R. (2020) Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle https://doi.org/10.1007/978-3-658-28032-1
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling)
 [^7]: Bär C., Fiege J., Weiß M. (2017) Projektcontrolling. In: Anwendungsbezogenes Projektmanagement. Xpert.press. Springer Vieweg, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-52974-4_8
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -47,7 +47,7 @@ Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im 
 Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**
 
 ### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
-Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt.[^13] Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.
+Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt. Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.[^13]
 
 ### Earned Value Analyse
 Eine weitere Methode ist die Earned Value Analyse, mit der man den Fertigstellungsgrad des Projekts bzw. einzelner Phasen ermitteln kann. Sie dient dem Projekt als Kontrollinstrument des Fortschritts. Diese Methode ist ebenfalls unter den Namen Leistungswertanalyse, Fertigstellungswertmethode oder Arbeitswertanalyse bekannt.[^7]

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -1,6 +1,6 @@
 ---
 title: Projektcontrolling
-tags: klassisch projektmanagement meilenstein
+tags: klassisch projektmanagement projektcontrolling projektsteuerung projektplanung meilenstein projekt
 author: hake1110
 anrechnung: k
 ---

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -95,9 +95,9 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 [^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) (abgerufen am 14.12.2021)
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
-[^5]: Fiedler R. (2020). *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle* https://doi.org/10.1007/978-3-658-28032-1
+[^5]: Fiedler R. (2020). *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle*.Springer Vieweg https://doi.org/10.1007/978-3-658-28032-1
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
-[^7]: Bär C., Fiege J., Weiß M. (2017) *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Xpert.press. Springer Vieweg, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-52974-4_8
+[^7]: Bär C., Fiege J., Weiß M. (2017). *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Xpert.press. Springer Vieweg. https://doi.org/10.1007/978-3-662-52974-4_8.
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
 [^9]: Beifuss A., Holzbaur U. (2020). *Projektcontrolling. In: Projektmanagement für Studierende*. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -95,11 +95,11 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 [^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) (abgerufen am 14.12.2021)
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
-[^5]: Fiedler R. (2020) Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle https://doi.org/10.1007/978-3-658-28032-1
+[^5]: Fiedler R. (2020) *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle* https://doi.org/10.1007/978-3-658-28032-1
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
-[^7]: Bär C., Fiege J., Weiß M. (2017) Projektcontrolling. In: Anwendungsbezogenes Projektmanagement. Xpert.press. Springer Vieweg, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-52974-4_8
+[^7]: Bär C., Fiege J., Weiß M. (2017) *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Xpert.press. Springer Vieweg, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-52974-4_8
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
-[^9]: Beifuss A., Holzbaur U. (2020) Projektcontrolling. In: Projektmanagement für Studierende. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
+[^9]: Beifuss A., Holzbaur U. (2020) *Projektcontrolling. In: Projektmanagement für Studierende*. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)
 [^11]: Steffens T. (2007) Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
 [^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -63,7 +63,7 @@ Den Mitarbeitern werden im Projektplan ihre Aufgaben sowie deren Bearbeitungszei
 Durch die Visualisierung der Arbeitspaketestatus mit Ampelfarben, ist die Methode besonders intuitiv. Ein Nachteil der Methode ist der Auslegungsspielraum der Ampelfarben. Um diese Gefahr zu minimieren, ist es unabdingbar, die Farben klar zu definieren. Gemeinhin bedeuten die verschiedenen Ampelphasen:
 * Grün:   Alles läuft nach Plan.
 * Gelb:   Es sind signifikante Planabweichungen zu befürchten.
-* Rot:    Eine Zielerreichung scheint nicht mehr möglich.[^3]
+* Rot:     Eine Zielerreichung scheint nicht mehr möglich.[^3]
 
 ### Soll-Ist-Vergleich
 Hierbei handelt es sich um eine simple, sich selbsterklärende Methode. Es werden die ermittelten Ist-Werte mit den vom Kunden vorgegebenen Soll-Werten verglichen.

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -46,10 +46,10 @@ Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im 
 
 Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**
 
-#### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
+### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
 Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt. Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.[^13]
 
-#### Earned Value Analyse
+### Earned Value Analyse
 Eine weitere Methode ist die Earned Value Analyse, mit der man den Fertigstellungsgrad des Projekts bzw. einzelner Phasen ermitteln kann. Sie dient dem Projekt als Kontrollinstrument des Fortschritts. Diese Methode ist ebenfalls unter den Namen Leistungswertanalyse, Fertigstellungswertmethode oder Arbeitswertanalyse bekannt.[^7]
 
 ### Projektplan

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -94,8 +94,8 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 # Quellen
 
 [^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) (abgerufen am 14.12.2021)
-[^4]: https://doi.org/10.1007/978-3-658-23714-1
-[^5]: Fiedler R. (2020). *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle*.Springer Vieweg https://doi.org/10.1007/978-3-658-28032-1
+[^4]: Zirkler B., Nobach K., Hofmann J., Behrens S. (2020). *Projektcontrolling: Leitfaden für die betriebliche Praxis*. Springer Gabler. https://doi.org/10.1007/978-3-658-23714-1
+[^5]: Fiedler R. (2020). *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle*. Springer Vieweg. https://doi.org/10.1007/978-3-658-28032-1.
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
 [^7]: Bär C., Fiege J., Weiß M. (2017). *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Springer Vieweg. https://doi.org/10.1007/978-3-662-52974-4_8.
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -16,7 +16,7 @@ Häufig wird (Projekt-)Controlling fälschlicherweise mit Kontrolle gleichgesetz
 
 Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach dem [Projektumfang](Projektumfang.md) richten sollte. Dabei kann sowohl das gesamte [Projekt](Projekt.md), als auch nur einzelne [Phasen](Projektphasen_klassisch.md) betrachtet werden.[^3]
 
-# Teilbereiche des Projektcontrollings[^6] 
+# Teilbereiche des Projektcontrollings 
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
 ## Projektkalkulation
@@ -26,7 +26,7 @@ In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. I
 Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
 
 ## Projektkontrolle
-Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten. 
+Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten.[^6] 
 
 # Kennzahlen und Methoden
 ## Kennzahlen

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -57,7 +57,7 @@ Den Mitarbeitern werden im Projektplan ihre Aufgaben sowie deren Bearbeitungszei
 * [Projektstrukturplan](Projektstrukturplan.md)
 * Ablaufplan (als Tabelle, [Netzplan](Netzplantechnik.md) oder [Gantt-Diagramm](Gantt_Diagramme.md))
 * [Kostenplan](Kostenplanung.md)
-* [Ressourcenplan](Ressourcenplanung.md) [^12]
+* [Ressourcenplan](Ressourcenplanung.md).[^12]
 
 ### Ampelmethode
 Durch die Visualisierung der Arbeitspaketestatus mit Ampelfarben, ist die Methode besonders intuitiv. Ein Nachteil der Methode ist der Auslegungsspielraum der Ampelfarben. Um diese Gefahr zu minimieren, ist es unabdingbar, die Farben klar zu definieren. Gemeinhin bedeuten die verschiedenen Ampelphasen:

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -19,7 +19,8 @@ Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach
 # Teilbereiche des Projektcontrollings 
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
-* **Projektkalkulation**
+* **Projektkalkulation:**
+
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
 ## Projektleistung

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -97,7 +97,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
 [^5]: Fiedler R. (2020). *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle*.Springer Vieweg https://doi.org/10.1007/978-3-658-28032-1
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
-[^7]: Bär C., Fiege J., Weiß M. (2017).*Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*.Springer Vieweg.https://doi.org/10.1007/978-3-662-52974-4_8.
+[^7]: Bär C., Fiege J., Weiß M. (2017). *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Springer Vieweg. https://doi.org/10.1007/978-3-662-52974-4_8.
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
 [^9]: Beifuss A., Holzbaur U. (2020). *Projektcontrolling. In: Projektmanagement für Studierende*. Springer Gabler. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -16,7 +16,7 @@ Häufig wird (Projekt-)Controlling fälschlicherweise mit Kontrolle gleichgesetz
 
 Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach dem [Projektumfang](Projektumfang.md) richten sollte. Dabei kann sowohl das gesamte [Projekt](Projekt.md), als auch nur einzelne [Phasen](Projektphasen_klassisch.md) betrachtet werden.[^3]
 
-# Teilbereiche des Projektcontrollings 
+# Teilbereiche des Projektcontrollings[^6] 
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
 ## Projektkalkulation
@@ -26,7 +26,7 @@ In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. I
 Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
 
 ## Projektkontrolle
-Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten. [^6]
+Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten. 
 
 # Kennzahlen und Methoden
 ## Kennzahlen
@@ -47,7 +47,7 @@ Mittlerweile finden viele, größtenteils standardisierte Methoden Anwendung im 
 Grundsätzlich gilt hier die Devise: **Je einfacher und durschaubarer die Methode, desto besser.**
 
 ### [Meilensteintrendanalyse](Meilensteintrendanalyse.md)
-Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt.[^13] Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich frühzeitig abzeichnende Trends erkenntlich werden.
+Die Definition von [Meilensteinen](Meilensteine.md) ist Grundlage dieser Methode. Diese werden am Anfang des Projekts für die [Projektplanung](Projektplanung.md) festgelegt.[^13] Die Meilensteintrendanalyse stellt Änderungen im Terminplan grafisch dar. Sie reiht alle [Meilenstein](Meilensteine.md)-Termine chronologisch auf, wodurch sich Trends frühzeitig abzeichnen.
 
 ### Earned Value Analyse
 Eine weitere Methode ist die Earned Value Analyse, mit der man den Fertigstellungsgrad des Projekts bzw. einzelner Phasen ermitteln kann. Sie dient dem Projekt als Kontrollinstrument des Fortschritts. Diese Methode ist ebenfalls unter den Namen Leistungswertanalyse, Fertigstellungswertmethode oder Arbeitswertanalyse bekannt.[^7]

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -5,7 +5,7 @@ author: hake1110
 anrechnung: k
 ---
 
-Das Projektcontrolling ist ein Bestandteil des [Projektmanagements](Projektmanagement.md).[^6] Es handelt sich dabei um einen [Steuerungs](Projektsteuerung.md)- und Koordinationsprozess[^4], der durch die [DIN 69901-5](https://de.wikipedia.org/wiki/DIN_69901) als "Sicherung des Erreichens der Projektziele durch: Soll-Ist-Vergleich, Feststellung der Abweichungen, Bewerten der Konsequenzen und Vorschlagen von Korrekturmaßnahmen, Mitwirkung bei der Maßnahmenplanung und Kontrolle der Durchführung" [^5]
+Das Projektcontrolling ist ein Bestandteil des [Projektmanagements](Projektmanagement.md).[^6] Es handelt sich dabei um einen [Steuerungs](Projektsteuerung.md)- und Koordinationsprozess[^4], der durch die DIN 69901-5 als "Sicherung des Erreichens der Projektziele durch: Soll-Ist-Vergleich, Feststellung der Abweichungen, Bewerten der Konsequenzen und Vorschlagen von Korrekturmaßnahmen, Mitwirkung bei der Maßnahmenplanung und Kontrolle der Durchführung" [^5]
 definiert wird.
 # Controlling Regelkreis
 Häufig wird (Projekt-)Controlling fälschlicherweise mit Kontrolle gleichgesetzt, es umfasst allerdings weitaus mehr. Die verschiedenen Schritte des Controlling-Prozesses sind in der folgenden Abbildung als projektspezifischer „Controlling Regelkreis“ illustriert.

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -97,7 +97,7 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
 [^5]: Fiedler R. (2020). *Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle*.Springer Vieweg https://doi.org/10.1007/978-3-658-28032-1
 [^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
-[^7]: Bär C., Fiege J., Weiß M. (2017). *Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*. Xpert.press. Springer Vieweg. https://doi.org/10.1007/978-3-662-52974-4_8.
+[^7]: Bär C., Fiege J., Weiß M. (2017).*Projektcontrolling. In: Anwendungsbezogenes Projektmanagement*.Springer Vieweg.https://doi.org/10.1007/978-3-662-52974-4_8.
 [^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
 [^9]: Beifuss A., Holzbaur U. (2020). *Projektcontrolling. In: Projektmanagement für Studierende*. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
 [^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -93,15 +93,15 @@ Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. 
 
 # Quellen
 
-[^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) 
+[^3]: [Projektmanagement Handbuch](https://www.projektmanagementhandbuch.de/handbuch/projektrealisierung/projektcontrolling/) (abgerufen am 14.12.2021)
 [^4]: https://doi.org/10.1007/978-3-658-23714-1
 [^5]: Fiedler R. (2020) Controlling von Projekten. Mit konkreten Beispielen aus der Unternehmenspraxis – Alle controllingrelevanten Aspekte der Projektplanung, Projektsteuerung und Projektkontrolle https://doi.org/10.1007/978-3-658-28032-1
-[^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling)
+[^6]: [Teilbereiche des Projektcontrollings](https://refa.de/service/refa-lexikon/projektcontrolling) (abgerufen am 14.12.2021)
 [^7]: Bär C., Fiege J., Weiß M. (2017) Projektcontrolling. In: Anwendungsbezogenes Projektmanagement. Xpert.press. Springer Vieweg, Berlin, Heidelberg. https://doi.org/10.1007/978-3-662-52974-4_8
-[^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings)
+[^8]: [Kennzahlen und Methoden des Projektcontrollings](https://de.wikipedia.org/wiki/Projektcontrolling#Kennzahlen_und_Methoden_des_Projektcontrollings) (abgerufen am 14.12.2021)
 [^9]: Beifuss A., Holzbaur U. (2020) Projektcontrolling. In: Projektmanagement für Studierende. essentials. Springer Gabler, Wiesbaden. https://doi.org/10.1007/978-3-658-32664-7_4
-[^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html)
+[^10]: [Ablaufschema des Projektcontrollings](https://www.geo.fu-berlin.de/en/v/proposal_writing/learning_content/7_project_management/controlling/index.html) (abgerufen am 14.12.2021)
 [^11]: Steffens T. (2007) Projektcontrolling. Methoden der Planung, Kontrolle und Steuerung, München, GRIN Verlag. https://www.grin.com/document/89579
-[^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan)
-[^13]: [Meilensteintrendanalyse](https://de.wikipedia.org/wiki/Meilensteintrendanalyse)
+[^12]: [Projektplan](https://www.projektmagazin.de/glossarterm/projektplan) (abgerufen am 14.12.2021)
+[^13]: [Meilensteintrendanalyse](https://de.wikipedia.org/wiki/Meilensteintrendanalyse) (abgerufen am 14.12.2021)
 [^14]: [Soll-Ist-Vergleich](https://www.kayenta.de/projektmanagement-glossar-lexikon/begriffserklaerung/soll-ist-vergleich.html) (abgerufen am 14.12.2021)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -67,7 +67,7 @@ Durch die Visualisierung der Arbeitspaketestatus mit Ampelfarben, ist die Method
 
 ### Soll-Ist-Vergleich
 Hierbei handelt es sich um eine simple, sich selbsterklärende Methode. Es werden die ermittelten Ist-Werte mit den vom Kunden vorgegebenen Soll-Werten verglichen.
-Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften uvw. sein. Aus dem Vergleich ergibt sich ein Gesamtunterschied zwischen den geplanten und tatsächlichen Werten. Sind die Ist-Werte besser als die Soll-Werte, fällt der Soll-Ist-Vergleich positiv, andernfalls negativ aus.[^14]
+Die Vergleichswerte können Kosten, Arbeitszeiten, Qualitätseigenschaften u.v.m. sein. Aus dem Vergleich ergibt sich ein Gesamtunterschied zwischen den geplanten und tatsächlichen Werten. Sind die Ist-Werte besser als die Soll-Werte, fällt der Soll-Ist-Vergleich positiv, andernfalls negativ aus.[^14]
 
 # Siehe auch
 * [Projektmanagement](Projektmanagement.md)

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -19,15 +19,15 @@ Dieser beschreibt einen sich wiederholenden Zyklus, dessen Häufigkeit sich nach
 # Teilbereiche des Projektcontrollings 
 Das Projektcontrolling lässt sich in die drei fundamentalen Teilbereiche Kalkulation, Leistung und Kontrolle untergliedern. Diese dienen Unternehmen als Basis zur Planung, Durchführung und Erfolgsbeurteilung der Projekte. 
 
-* **Projektkalkulation:**
+**Projektkalkulation:**
 
 In der Vorbereitungs- und Planungsphase erfolgt die Kalkulation des Projektes. In diesem Zeitraum werden Gesamtkosten, variable Kosten sowie Fixkosten systematisch erhoben. Bei mittel- bis langfristigen Projekten ist es sinnvoll, das Projekt in mehrere Abschnitte zu untergliedern. Das hat den Vorteil, dass man jeder Etappe gesondert die entstandenen Kosten zuordnen kann.
 
-* **Projektleistung:**
+**Projektleistung:**
 
 Zu Beginn werden qualitative Merkmale des Projekts, die Projektleistung, determiniert. Das Projektcontrolling hat die Aufgabe, diese zu kontrollieren, um bei potentiellen Abweichungen frühzeitig Gegenmaßnahmen einzuleiten.
 
-* **Projektkontrolle:**
+**Projektkontrolle:**
 
 Soll und Ist-Kosten des Projekts werden über den gesamten [Projektlebenszyklus](Projekt_Lebenszyklus.md) im Blick behalten, um Kostenabweichungen zu identifizieren. Eine reine Gegenüberstellung der Kosten liefert nur bedingt einen Mehrwert. Diese Vorgehensweise berücksichtigt nicht, ob das Projekt durch Beschleunigungskosten vorzeitig fertiggestellt werden kann. Eine Termin-Kosten-Kontrolle hingegen, verschafft einen genaueren Einblick in die Gesamtkosten.[^6] 
 

--- a/kb/Projektcontrolling.md
+++ b/kb/Projektcontrolling.md
@@ -57,7 +57,7 @@ Den Mitarbeitern werden im Projektplan ihre Aufgaben sowie deren Bearbeitungszei
 * [Projektstrukturplan](Projektstrukturplan.md)
 * Ablaufplan (als Tabelle, [Netzplan](Netzplantechnik.md) oder [Gantt-Diagramm](Gantt_Diagramme.md))
 * [Kostenplan](Kostenplanung.md)
-* [Ressourcenplan](Ressourcenplanung.md)[^12]
+* [Ressourcenplan](Ressourcenplanung.md) [^12]
 
 ### Ampelmethode
 Durch die Visualisierung der Arbeitspaketestatus mit Ampelfarben, ist die Methode besonders intuitiv. Ein Nachteil der Methode ist der Auslegungsspielraum der Ampelfarben. Um diese Gefahr zu minimieren, ist es unabdingbar, die Farben klar zu definieren. Gemeinhin bedeuten die verschiedenen Ampelphasen:


### PR DESCRIPTION
Zu den Verbesserungsvorschlägen der Reviewer: 
- Ich habe den Beitrag von ca. 660 Wörter auf 600 Wörter gekürzt, obwohl beide Größenordnungen wie gesagt im Rahmen liegen.
- Die einleitende Kurzbeschreibung des Begriffs habe ich noch einmal aufgeteilt , sodass der Controlling Regelkreis einen eigenen Absatz bekommen hat und die Kurzbeschreibung kurz und prägnant bleibt.
- Ich habe mich bewusst gegen eine Nummerierung der Überschriften entschieden, da die Artikel ja einen Wikipedia-Artikel Charakter erhalten sollen und die Untergliederung durch die verschiedenen Ebenen (#,##,###) der Überschriften deutlich wird. Außerdem habe ich bei dem Absatz "Teilprojekte des Projektcontrolling" die Unterüberschriften rausgenommen, wodurch es übersichtlicher wurde.
- Die Links bzw. URL habe ich durch die Titel der Websiten bzw. Videos ersetzt
- Rechtschreibung bzw. Grammatikfehler wurden korrigiert.