### PR TITLE
Update Tuckmann Ladder nach #1. Review

### DIFF
--- a/kb/Tuckmann_Ladder.md
+++ b/kb/Tuckmann_Ladder.md
@@ -5,13 +5,11 @@ author: ebressel
 anrechnung: k 
 ---
 
-Neue Teams :family_man_man_girl_boy: leiden häufig unter dem Mangel eines Gemeinschaftsgefühls - die Mitglieder eines Teams können nicht effizient zusammenarbeiten, wenn sie keine Zeit haben, sich gegenseitig kennenzulernen. Im Jahr 1965 entwickelte der Psychologe Bruce Tuckman ein leicht verständliches Modell, das zeigt, wie Teams in verschiedenen Bereichen die gleichen Phasen der Gruppenentwicklung durchlaufen[^1]. Wenn Sie diese fünf Phasen der Teamentwicklung kennen, können Sie erfolgreiche Teams bilden, die ihr volles Potenzial ausschöpfen.
+Im [Projektmanagement](Projektmanagement.md) (PM) verlangen viele Aufgaben nach enger Zusammenarbeit mehrerer Köpfe mit unterschiedlichen Kompetenzen und Denkweisen. Dafür werden Teams gebildet. Damit diese Teamarbeit nicht im unproduktiven Chaos versinkt, braucht es eine koordinierte Teamentwicklung. 1965 entwickelte der Psychologe Bruce Tuckman ein leicht verständliches Modell, das zeigt, wie verschiedene Teams die gleichen Phasen der Gruppenentwicklung durchlaufen[^1].
 
-# Das Tuckman-Modell der Gruppenentwicklung
-## Von Diskrepanz zum Wir-Gefühl  :ng_man::arrow_right: :people_holding_hands:
+# Das Tuckman-Modell der Gruppenentwicklung - Von Diskrepanz zum Wir-Gefühl
 
-Der Psychologe Bruce Tuckman entwickelte 1965 sein **Gruppenentwicklungsmodell**, um zu erklären, wie gesunde Teams mit der Zeit zusammenwachsen. In Tuckmans Modell werden fünf
-Phasen unterschieden, die Gruppen durchlaufen: **Forming, Storming, Norming, Performing und Adjourning** (siehe Abbildung 1). Jede der fünf Phasen der Teamentwicklung stellt eine Stufe auf der Leiter der Teamentwicklung dar[^1]. Während die Gruppenmitglieder die "Leiter" erklimmen, verwandeln sie sich von einer zufälligen Ansammlung von Fremden in ein leistungsstarkes Team, das auf ein gemeinsames Ziel hinarbeiten kann[^2]. Im Folgenden werden die fünf Stufen der Gruppenentwicklung von Tuckman im Detail erläutert:
+Im PM sollte bei der Bildung eines neuen Projektteams, in dem sich die einzelnen Teammitglieder nicht kennen, mit Konflikten gerechnet werden. Zur Bewältigung solcher Konflikte ist es hilfreich, wenn der [Projektleiter](Projektleiter.md) weiß, wie sich Teams in der Regel entwickeln[^1]. Eines der populäreren **klassischen Modelle** der Teamentwicklung ist die so genannte **"Tuckman-Ladder"**(siehe Abbildung 1), die besagt, dass Teams die folgenden Entwicklungsphasen durchlaufen[^2]: 
 
 ![Stages_Tuckman_model](https://user-images.githubusercontent.com/92668932/143244002-85eb062a-88a5-4d62-a6bd-6aa6eec4b78a.png)
 
@@ -19,42 +17,39 @@ Phasen unterschieden, die Gruppen durchlaufen: **Forming, Storming, Norming, Per
 
 ## Forming: die Orientierungsphase
 
-Diese ist die Erste in Tuckmans Phasen der Gruppenentwicklung und ähnelt der Erfahrung, die Sie an Ihrem ersten Tag in einem neuen Job machen. Hier lernt
-sich das Team kennen und es geht hauptsächlich darum, allen Mitgliedern eine Orientierung zu geben, wie die Gruppe zusammenarbeiten wird. Da die **Gruppendynamik und die Rollen im Team noch nicht festgelegt** sind, übernimmt der Teamleiter oft die Führung und leitet die einzelnen Mitglieder an. Während der Forming-Phase nach Tuckman können die neuen
-Teammitglieder über Teamziele, Grundregeln und individuelle Rollen diskutieren[^4]. 
+In der ersten Phase lernt sich das Team kennen und allen Mitgliedern soll eine Orientierung gegeben werden, wie die Gruppe zusammenarbeiten wird. Da die **Gruppendynamik und die Rollen im Team noch nicht festgelegt** sind, übernimmt der Teamleiter oft die Führung und leitet die einzelnen Mitglieder an [^4]. 
 
 ## Storming: die Konfrontationsphase
 
-Eine entscheidende, aber vielleicht auch die wichtigste Phase ist die "Storming"-Phase. Diese Phase ist vor allem von **Konflikten, Spannungen und Wettbewerb** geprägt, da sich die **einzelnen Persönlichkeiten herausbilden**. Bei Teams entsteht der Konflikt oft durch gegensätzliche Arbeitsstile der Teammitglieder. Manche beginnen sogar, an den zuvor
-besprochenen Zielen des Teams zu zweifeln und stellen ihre Arbeit ganz ein. Als Folge kann sich dies negativ und belastend auf diejenigen auswirken, die die harte Arbeit
-fortsetzen, da die zuvor etablierten Gruppenprozesse nicht mehr reibungslos funktionieren. Aus diesem Grund ist in dieser Phase ist der **Teamleader** ganz besonders gefragt: Er muss die Konflikte entschärfen und eine gemeinsame Richtung vorgeben[^5]. Um ein Scheitern zu verhindern, liegt es am Ende bei den Mitglieder, die individuellen Unterschiede akzeptieren[^3].
+Die sehr entscheidende "Storming"-Phase, ist vor allem von **Konflikten, Spannungen und Wettbewerb** geprägt, da sich die **einzelnen Persönlichkeiten herausbilden**. Bei Teams entsteht der Konflikt oft durch gegensätzliche Arbeitsstile der Teammitglieder. Aus diesem Grund ist in dieser Phase ist der **Teamleader** ganz besonders gefragt: Er muss die Konflikte entschärfen und eine gemeinsame Richtung vorgeben[^5] [^3].
 
 ## Norming: die Organisationsphase
 
-Wenn die Mitglieder die "Storming"-Phase hinter sich gelassen haben, akzeptieren sie sich gegenseitig mehr und beginnen, sich **auf gemeinsame Ziele zu konzentrieren**. In der
-"Norming"-Phase werden zwischenmenschliche Differenzen abgebaut, und die Mitglieder suchen nun aktiv nach **gegenseitiger Unterstützung**, um auf ein gemeinsames Ziel hinzuarbeiten. Das Team ist in der Lage effektiv mit **konstruktivem Feedback** zu arbeiten, da sich die Mitglieder mit den Teamabläufen vertraut gemacht haben und neuer Aufgaben bewältigen können. Da diese **neuen Aufgaben** oft mit einem hohen Schwierigkeitsgrad verbunden sind, ist es nicht ungewöhnlich, dass Gruppen wieder in die Storming-Phase zurückfallen[^1][^5]. 
+Wenn die Mitglieder die "Storming"-Phase hinter sich gelassen haben, beginnen sie, sich **auf gemeinsame Ziele zu konzentrieren**. Nun werden zwischenmenschliche Differenzen abgebaut und die Mitglieder suchen nun aktiv nach **gegenseitiger Unterstützung**. Das Team ist in der Lage effektiv mit **konstruktivem Feedback** zu arbeiten, da sich die Mitglieder mit den Teamabläufen vertraut gemacht haben.[^1][^5]. 
 
 ## Performing: die Leistungsphase
 
-In der Durchführungsphase konzentrieren sich alle Mitglieder gemeinsam auf die **Erledigung der Aufgabe** und sind nun in der Lage, **effektiv zu kommunizieren**. In dieser Phase ist die Leistung des Teams so hoch wie nie zuvor. Dieses **hohe Leistungsniveau** bedeutet, dass alle Teammitglieder selbständig sind und so viel **Vertrauen** in ihre eigenen Problemlösungsfähigkeiten haben, dass sie ohne Aufsicht durch die Leiter funktionieren können. Alle arbeiten wie eine gut geölte Maschine, konfliktfrei und synchron auf ein gemeinsames Endziel hin[^5].
+In der Durchführungsphase ist die Leistung des Teams so hoch wie nie zuvor. Dieses **hohe Leistungsniveau** bedeutet, dass alle Teammitglieder selbständig sind und so viel **Vertrauen** in ihre eigenen Problemlösungsfähigkeiten haben, dass sie ohne Aufsicht durch die Leiter funktionieren können [^5].
 
 ### Übersicht der ersten vier Phasen
 
 Die folgende Tabelle fasst die Phasen mit jeweiligen Herausforderungen zusammen, die im Zusammenhang mit einer neuen Teambildung und -entwicklung aufkommen können. 
 
-  | :busts_in_silhouette: | Forming | Storming | Norming | Performing |
+  | ° | Forming | Storming | Norming | Performing |
   | ------------- | ------------- | ------------- | ------------- | ------------- |
-  | **Allgemeine Feststellungen** | Unklarheit über die Rollen; Suche nach Orientierung durch Außenstehende | Wachsendes Vertrauen in das Team; Ablehnung von Autorität von außen |     Die Sorge, anders zu sein; der Wunsch, Teil eines Teams zu sein | Besorgnis über die Erledigung der Arbeit |
-  | **Prozessbezogene Probleme** | Die Teammitglieder wenden sich an ihre Vorgesetzten, um Anleitung und Orientierung zu erhalten |Das Team lehnt die Aufgabe ab und sucht nach         Gründen, sie nicht zu erledigen | Das Team beginnt mit der Einrichtung von Verfahren zur Bewältigung der Aufgabe | Das Team ist in der Lage, Probleme zu lösen |
-  | **Gefühlsbezogene Probleme** | Die Mitglieder fühlen sich verunsichert und sind sich ihrer Rolle nicht sicher | Die Menschen fühlen sich noch unsicher und versuchen, ihre          Individualität zum Ausdruck zu bringen. Es entstehen Bedenken hinsichtlich der Teamhierarchie | Die Menschen ignorieren individuelle Unterschiede und akzeptieren einander        mehr | Die Mitarbeiter haben einen gemeinsamen Fokus, kommunizieren effektiv und werden dadurch effizienter und flexibler |
+  | **Allgemeine Feststellungen** | Unklarheit über die Rollen | Wachsendes Vertrauen in das Team; Ablehnung von Autorität von außen | Der Wunsch, Teil eines Teams zu sein | Besorgnis über die Erledigung der Arbeit |
+  | **Prozessbezogene Probleme** | Die Teammitglieder wenden sich an ihre Vorgesetzten, um Orientierung zu erhalten |Das Team lehnt die Aufgabe ab und sucht nach Gründen, sie nicht zu erledigen | Das Team beginnt mit der Einrichtung von Verfahren zur Bewältigung der Aufgabe | Das Team ist in der Lage, Probleme zu lösen |
 
 *Tabelle 1: Überblick der Phasen Forming, Storming, Norming, Performing* [^6]
 
 ## Adjouring: die Auflösungsphase
 
-Die fünfte Phase geht davon aus, dass Projektteams nur für einen **bestimmten Zeitraum** bestehen; sobald die Aufgabe des Teams erfüllt ist, löst sich das Team selbst auf. 
-Nicht selten wird diese Phase manchmal auch als **"Trauerphase"** bezeichnet, da die Teammitglieder häufig ein Gefühl des Verlustes empfinden, wenn die Gruppe aufgelöst wird[^5][^7].
+Die fünfte Phase geht davon aus, dass Projektteams nur für einen **bestimmten Zeitraum** bestehen; sobald der [Projektabschluss](Projektabschluss.md) eintritt, löst sich das Team selbst auf[^5].
+Zwar durchlaufen die Teams diese Phasen in der Regel in der aufgeführten Reihenfolge, dennoch ist es wichtig zu erwähnen, dass sie in einer oder mehreren Phasen stecken bleiben oder zu einer früheren Phase zurückkehren können[^7].
 
+# Fazit zur Teamentwicklung
+
+Ein harmonisches Team ist die Basis für ein erfolgreiches Unternehmen. Damit sich die Teammitglieder in einem Projekt gegenseitig vertrauen und unterstützen, braucht es geeignetes [Teammanagement](Teammanagement.md). Diese sollten auf die einzelnen [Projektmitarbeiter](Projektmitarbeiter), die Unternehmenswerte sowie die Entwicklungsziele abgestimmt werden, um ein Projekt erfolgreich druchzuführen. 
 
 # Siehe auch
 

--- a/kb/Tuckmann_Ladder.md
+++ b/kb/Tuckmann_Ladder.md
@@ -5,11 +5,11 @@ author: ebressel
 anrechnung: k 
 ---
 
-Im [Projektmanagement](Projektmanagement.md) (PM) verlangen viele Aufgaben nach enger Zusammenarbeit mehrerer Köpfe mit unterschiedlichen Kompetenzen und Denkweisen. Dafür werden Teams gebildet. Damit diese Teamarbeit nicht im unproduktiven Chaos versinkt, braucht es eine koordinierte Teamentwicklung. 1965 entwickelte der Psychologe Bruce Tuckman ein leicht verständliches Modell, das zeigt, wie verschiedene Teams die gleichen Phasen der Gruppenentwicklung durchlaufen[^1].
+Im [Projektmanagement](Projektmanagement.md) (PM) verlangen viele Aufgaben nach enger Zusammenarbeit mehrerer Köpfe mit unterschiedlichen Kompetenzen und Denkweisen. Dafür werden Teams gebildet. Damit diese Teamarbeit nicht im unproduktiven Chaos versinkt, braucht es eine koordinierte [Teamentwicklung](https://de.wikipedia.org/wiki/Teambildung). Im Jahr 1965 entwickelte der Psychologe Bruce Tuckman ein leicht verständliches Modell, das zeigt, wie verschiedene Teams die gleichen Phasen der Gruppenentwicklung durchlaufen[^1].
 
 # Das Tuckman-Modell der Gruppenentwicklung - Von Diskrepanz zum Wir-Gefühl
 
-Im PM sollte bei der Bildung eines neuen Projektteams, in dem sich die einzelnen Teammitglieder nicht kennen, mit Konflikten gerechnet werden. Zur Bewältigung solcher Konflikte ist es hilfreich, wenn der [Projektleiter](Projektleiter.md) weiß, wie sich Teams in der Regel entwickeln[^1]. Eines der populäreren **klassischen Modelle** der Teamentwicklung ist die so genannte **"Tuckman-Ladder"**(siehe Abbildung 1), die besagt, dass Teams die folgenden Entwicklungsphasen durchlaufen[^2]: 
+Bei der Bildung eines neuen Projektteams, in dem sich die einzelnen Teammitglieder nicht kennen, mit Konflikten gerechnet werden. Zur Bewältigung solcher Konflikte ist es hilfreich, wenn der [Projektleiter](Projektleiter.md) weiß, wie sich Teams in der Regel entwickeln[^1]. Eines der populäreren **klassischen Modelle** der Teamentwicklung ist die so genannte **"Tuckman-Ladder"**(siehe Abbildung 1), die besagt, dass Teams die folgenden Entwicklungsphasen durchlaufen[^2]: 
 
 ![Stages_Tuckman_model](https://user-images.githubusercontent.com/92668932/143244002-85eb062a-88a5-4d62-a6bd-6aa6eec4b78a.png)
 
@@ -21,11 +21,11 @@ In der ersten Phase lernt sich das Team kennen und allen Mitgliedern soll eine O
 
 ## Storming: die Konfrontationsphase
 
-Die sehr entscheidende "Storming"-Phase, ist vor allem von **Konflikten, Spannungen und Wettbewerb** geprägt, da sich die **einzelnen Persönlichkeiten herausbilden**. Bei Teams entsteht der Konflikt oft durch gegensätzliche Arbeitsstile der Teammitglieder. Aus diesem Grund ist in dieser Phase ist der **Teamleader** ganz besonders gefragt: Er muss die Konflikte entschärfen und eine gemeinsame Richtung vorgeben[^5] [^3].
+Die sehr entscheidende "Storming"-Phase, ist vor allem von **Konflikten, Spannungen und Wettbewerb** geprägt, da sich die **einzelnen Persönlichkeiten herausbilden**. Bei Teams entsteht der Konflikt oft durch gegensätzliche Arbeitsstile der Teammitglieder. Aus diesem Grund ist in dieser Phase ist der **Teamleiter** ganz besonders gefragt: Er muss die Konflikte entschärfen und eine gemeinsame Richtung vorgeben[^5] [^3].
 
 ## Norming: die Organisationsphase
 
-Wenn die Mitglieder die "Storming"-Phase hinter sich gelassen haben, beginnen sie, sich **auf gemeinsame Ziele zu konzentrieren**. Nun werden zwischenmenschliche Differenzen abgebaut und die Mitglieder suchen nun aktiv nach **gegenseitiger Unterstützung**. Das Team ist in der Lage effektiv mit **konstruktivem Feedback** zu arbeiten, da sich die Mitglieder mit den Teamabläufen vertraut gemacht haben.[^1][^5]. 
+Wenn die Mitglieder die "Storming"-Phase hinter sich gelassen haben, beginnen sie, sich **auf gemeinsame Ziele zu konzentrieren**. Nun werden zwischenmenschliche Differenzen abgebaut und die Mitglieder suchen nun aktiv nach **gegenseitiger Unterstützung**. Das Team ist in der Lage effektiv mit **konstruktivem [Feedback](https://de.wikipedia.org/wiki/Feedback_(Gruppendynamik))** zu arbeiten, da sich die Mitglieder mit den Teamabläufen vertraut gemacht haben.[^1][^5]. 
 
 ## Performing: die Leistungsphase
 
@@ -49,7 +49,7 @@ Zwar durchlaufen die Teams diese Phasen in der Regel in der aufgeführten Reihen
 
 # Fazit zur Teamentwicklung
 
-Ein harmonisches Team ist die Basis für ein erfolgreiches Unternehmen. Damit sich die Teammitglieder in einem Projekt gegenseitig vertrauen und unterstützen, braucht es geeignetes [Teammanagement](Teammanagement.md). Diese sollten auf die einzelnen [Projektmitarbeiter](Projektmitarbeiter), die Unternehmenswerte sowie die Entwicklungsziele abgestimmt werden, um ein Projekt erfolgreich druchzuführen. 
+Ein harmonisches Team ist die Basis für ein erfolgreiches Unternehmen. Damit sich die Teammitglieder in einem Projekt gegenseitig vertrauen und unterstützen, braucht es geeignetes [Teammanagement](Teammanagement.md). Diese sollten auf die einzelnen [Projektmitarbeiter](Projektmitarbeiter.md), die [Unternehmenswerte](https://de.wikipedia.org/wiki/Unternehmenswert) sowie die Entwicklungsziele abgestimmt werden, um ein Projekt erfolgreich druchzuführen. 
 
 # Siehe auch
 

--- a/kb/Tuckmann_Ladder.md
+++ b/kb/Tuckmann_Ladder.md
@@ -60,9 +60,9 @@ Ein harmonisches Team ist die Basis für ein erfolgreiches Unternehmen. Damit si
 
 # Weiterführende Literatur
 
-* Tuckman, B. W. (1965). Developmental sequence in small groups. Psychological Bulletin, 63(6), 384–399. https://doi.org/10.1037/h0022100
-* Xu, H. , Chen, Z. and Mao, J. (2020) Inhibition or Facilitation? A Review of Research on the Effects of Uncertainty Stimuli on User Psychology and Behavior. American Journal of Industrial and Business Management, 10, 1586-1604. doi: 10.4236/ajibm.2020.109101.
-* Jong, Ad & de ruyter, ko & Wetzels, Martin. (2005). Antecedents and Consequences of Group Potency: A Study of Self-Managing Service Teams. Management Science. 51. 1610-1625. 10.1287/mnsc.1050.0425. 
+* [Developmental sequence in small groups.](https://psycnet.apa.org/record/1965-12187-001)
+* [Inhibition or Facilitation? A Review of Research on the Effects of Uncertainty Stimuli on User Psychology and Behavior.](https://www.researchgate.net/publication/345362880_Inhibition_or_Facilitation_A_Review_of_Research_on_the_Effects_of_Uncertainty_Stimuli_on_User_Psychology_and_Behavior)
+* [Antecedents and Consequences of Group Potency: A Study of Self-Managing Service Teams.](https://www.researchgate.net/publication/220534522_Antecedents_and_Consequences_of_Group_Potency_A_Study_of_Self-Managing_Service_Teams)
 
 # Quellen
 
@@ -72,4 +72,5 @@ Ein harmonisches Team ist die Basis für ein erfolgreiches Unternehmen. Damit si
 [^6]: [Stages of Small-Group Development Revisited](https://webspace.science.uu.nl/~daeme101/Stages%20of%20Small-Group%20Development%20Revisted.pdf)
 [^5]: [Teamphasen nach Tuckman](https://www.wsu-beratung.de/blog/teamphasen)
 [^7]: [Scheiden tut weh: Adjourning – die unterschätzte Phase im Teamprozess](https://teamworks-gmbh.de/scheiden-tut-weh-adjourning-die-unterschaetzte-phase-im-teamprozess/)
+[^7]: [Project Management: A Strategic Managerial Approach](https://books.google.de/books?id=ipZXDwAAQBAJ&pg=PA87&lpg=PA87&dq=tuckman+ladder+classic+management&source=bl&ots=Qxn-qMDClZ&sig=ACfU3U31NTWnn_zW8I6ZgZBg6ewJvmwlvQ&hl=de&sa=X&ved=2ahUKEwj_sPSE9fT0AhUGCuwKHVtvBWsQ6AF6BAgtEAM#v=onepage&q=tuckman%20ladder%20classic%20management&f=false)
 [^1]: [Agiles Coaching: Die neue Art, Teams zum Erfolg zu führen](https://books.google.de/books?id=iV6yDwAAQBAJ&lpg=PT335&ots=KQiYmuqrjk&dq=adjourning%20als%20trauerphase&hl=de&pg=PT335#v=onepage&q=adjourning%20als%20trauerphase&f=false)

--- a/kb/Tuckmann_Ladder.md
+++ b/kb/Tuckmann_Ladder.md
@@ -5,7 +5,7 @@ author: ebressel
 anrechnung: k 
 ---
 
-Im [Projektmanagement](Projektmanagement.md) (PM) verlangen viele Aufgaben nach enger Zusammenarbeit mehrerer Köpfe mit unterschiedlichen Kompetenzen und Denkweisen. Dafür werden Teams gebildet. Damit diese Teamarbeit nicht im unproduktiven Chaos versinkt, braucht es eine koordinierte [Teamentwicklung](https://de.wikipedia.org/wiki/Teambildung). Im Jahr 1965 entwickelte der Psychologe Bruce Tuckman ein leicht verständliches Modell, das zeigt, wie verschiedene Teams die gleichen Phasen der Gruppenentwicklung durchlaufen[^1].
+Im [Projektmanagement](Projektmanagement.md) (PM) verlangen viele Aufgaben nach enger Zusammenarbeit der [Projektmitarbeiter](Projektmitarbeiter.md) mit unterschiedlichen Kompetenzen und Denkweisen - dafür werden Teams gebildet. Damit diese Teamarbeit nicht im unproduktiven Chaos versinkt, braucht es eine koordinierte [Teamentwicklung](https://de.wikipedia.org/wiki/Teambildung). Im Jahr 1965 entwickelte der Psychologe Bruce Tuckman ein leicht verständliches Modell, das zeigt, wie verschiedene Teams die gleichen Phasen der Gruppenentwicklung durchlaufen[^1].
 
 # Das Tuckman-Modell der Gruppenentwicklung - Von Diskrepanz zum Wir-Gefühl
 


### PR DESCRIPTION
Updates zu (Basierend auf dem Feedback/Reviews):

Textlänge gekürzt
Fazit am Ende hinzugefügt
Verlinkungen zu relevanten Themen/anderen Beiträgen hinzugefügt
Links sollten nun alle funktionieren
Wegfall der doppelten Überschrift